### PR TITLE
make version requirement less strict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "nyrag"
 version = "0.0.7"
 description = "nyrag"
 readme = "README.md"
-requires-python = "==3.10"
+requires-python = "==3.10.*"
 authors = [
     { name = "abhishek" }
 ]


### PR DESCRIPTION
For instance, if you want to deploy to a hugging face space where you don't have complete control over the python environment, you need flexibility in the python version.