### PR TITLE
Fix: Sanitize control characters before feeding to Vespa

### DIFF
--- a/src/nyrag/cli.py
+++ b/src/nyrag/cli.py
@@ -42,7 +42,7 @@ def main():
         logger.info("Vespa feeding enabled - documents will be fed to Vespa as they are processed")
 
         # Process based on config
-        process_from_config(config, resume=args.resume)
+        process_from_config(config, resume=args.resume, config_path=args.config)
 
         logger.success(f"Processing complete! Output saved to {config.get_output_path()}")
 


### PR DESCRIPTION
## Problem
When processing PDF documents, some files contain illegal XML control characters (like 0x0C - form feed) that cause Vespa to reject the feed with error:

`Could not parse field 'content' of type string: The string field value contains illegal code point 0xC`


## Solution
Added `_sanitize_xml_content()` function in `feed.py` that removes illegal control characters before feeding to Vespa.

XML/JSON only allows these control characters:
- 0x09 (TAB)
- 0x0A (LF)
- 0x0D (CR)

All other control characters (0x00-0x08, 0x0B, 0x0C, 0x0E-0x1F, 0x7F) are now removed.

## Testing
Tested with PDF documents that previously failed to index. After this fix, they index successfully.
