### PR TITLE
docs: add Requesty as an OpenAI-compatible provider option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # LLM API configuration (required for chat answers)
 LLM_BASE_URL=https://openrouter.ai/api/v1
+# Requesty (OpenAI-compatible): LLM_BASE_URL=https://router.requesty.ai/v1
 LLM_API_KEY=your-llm-api-key-here
 LLM_MODEL=openai/gpt-5.1
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This multi-query RAG approach with chunk-level retrieval ensures answers are com
 
 NyRAG works with **any OpenAI-compatible API**, including:
 - **OpenRouter** (100+ models from various providers)
+- **Requesty** (OpenAI-compatible gateway, 400+ models)
 - **Ollama** (local models: Llama, Mistral, Qwen, etc.)
 - **LM Studio** (local GUI for running models)
 - **vLLM** (high-performance local or remote inference)
@@ -167,6 +168,7 @@ NyRAG works with any OpenAI-compatible API. Just configure the `rag_params` in y
 | **LM Studio** | `http://localhost:1234/v1` | `local-model` | `dummy` |
 | **vLLM** | `http://localhost:8000/v1` | `meta-llama/Llama-3.2-3B-Instruct` | `dummy` |
 | **OpenRouter** | `https://openrouter.ai/api/v1` | `openai/gpt-5.2` | `your-key` |
+| **Requesty** | `https://router.requesty.ai/v1` | `openai/gpt-4o-mini` | `your-key` |
 | **OpenAI** | `None` (default) | `openai/gpt-4o` | `your-key` |
 
 **Example Config:**

--- a/src/nyrag/examples/doc.yml
+++ b/src/nyrag/examples/doc.yml
@@ -29,6 +29,9 @@ rag_params:
 
 # Optional: LLM configuration (works with any OpenAI-compatible API)
 llm_config:
+  # For OpenRouter (default):
   base_url: https://openrouter.ai/api/v1
   model: anthropic/claude-3.5-sonnet
   api_key: your-openrouter-key
+
+  # For Requesty: base_url: https://router.requesty.ai/v1

--- a/src/nyrag/examples/web.yml
+++ b/src/nyrag/examples/web.yml
@@ -35,6 +35,8 @@ llm_config:
   base_url: https://openrouter.ai/api/v1
   model: anthropic/claude-3.5-sonnet
   api_key: your-openrouter-key
+
+  # For Requesty: base_url: https://router.requesty.ai/v1
   
   # For Ollama (local):
   # base_url: http://localhost:11434/v1


### PR DESCRIPTION
This adds Requesty as an OpenAI-compatible provider option alongside the existing OpenRouter entry, leaving OpenRouter as the default.

Requesty is an OpenAI-compatible LLM gateway, so it works with NyRAG's existing client without code changes — only the base URL and `provider/model` naming differ.

Changes (docs/config/examples only, no code or default changes):
- README.md: added a `**Requesty**` bullet to the LLM Support list and a provider-table row (`https://router.requesty.ai/v1`, `openai/gpt-4o-mini`), mirroring the OpenRouter row.
- .env.example: added a commented Requesty alternative beside the OpenRouter default `LLM_BASE_URL` (default value unchanged).
- src/nyrag/examples/web.yml and doc.yml: added a commented `# For Requesty: base_url: https://router.requesty.ai/v1` line beside the existing OpenRouter comment.

OpenRouter remains the default everywhere.

I verified a live chat completion against `https://router.requesty.ai/v1` with `openai/gpt-4o-mini` (HTTP 200, valid completion).

Links:
- https://requesty.ai
- https://docs.requesty.ai

I work at Requesty. This mirrors the existing OpenRouter option as closely as possible. Happy to adjust or close it if it's not a fit.
